### PR TITLE
Fix cursor transactions not committing on exit

### DIFF
--- a/asqlite.py
+++ b/asqlite.py
@@ -110,7 +110,7 @@ class _ContextManagerMixin:
 
     async def __aexit__(self, exc_type, exc, tb):
         if self.__result is not None:
-            await self.__result.close()
+            await self.__result.__aexit__(exc_type, exc, tb)
 
 class Cursor:
     """An asyncio-compatible version of :class:`sqlite3.Cursor`.


### PR DESCRIPTION
Fixes `Connection.cursor(transaction=True)` not committing or rolling back when the cursor is exiting:
```py
async with asqlite.connect(...) as conn:
    async with conn.cursor(transaction=True) as c:  # c.start()
        await c.execute(...)
    # forgets to commit; c.close()
```
This stems from `_ContextManagerMixin` invoking the result's `close()` method when exiting, whereas the commit/rollback logic is implemented in `_CursorWithTransaction.__aexit__`.