### PR TITLE
Add cursor fluent-style chaining

### DIFF
--- a/asqlite/__init__.py
+++ b/asqlite/__init__.py
@@ -148,15 +148,18 @@ class Cursor:
         """Asynchronous version of :meth:`sqlite3.Cursor.execute`."""
         if len(parameters) == 1 and isinstance(parameters[0], (dict, tuple)):
             parameters = parameters[0]
-        return await self._post(self._cursor.execute, sql, parameters)
+        await self._post(self._cursor.execute, sql, parameters)
+        return self
 
     async def executemany(self, sql, seq_of_parameters):
         """Asynchronous version of :meth:`sqlite3.Cursor.executemany`."""
-        return await self._post(self._cursor.executemany, sql, seq_of_parameters)
+        await self._post(self._cursor.executemany, sql, seq_of_parameters)
+        return self
 
     async def executescript(self, sql_script):
         """Asynchronous version of :meth:`sqlite3.Cursor.executescript`."""
-        return await self._post(self._cursor.executescript, sql_script)
+        await self._post(self._cursor.executescript, sql_script)
+        return self
 
     async def fetchone(self):
         """Asynchronous version of :meth:`sqlite3.Cursor.fetchone`."""


### PR DESCRIPTION
This allows chaining execute*, fetch*, start, commit, and rollback methods of `Cursor`/`_CursorWithTransaction` and also execute* methods of `Connection` as such:
```py
async with asqlite.connect(':memory:') as conn:
    row = await conn.executescript(
        'CREATE TABLE test (id INTEGER);'
        'INSERT INTO test VALUES (1);'
    ).execute(
        'SELECT * FROM test;'
    ).fetchone()

    async with conn.execute(
            'INSERT INTO test VALUES (2);').execute(
            'SELECT * FROM test;') as c:
        rows = await c.fetchall()
```
This is related to issue #5 which attempted chaining an execute and fetchone, resulting an an exception due to trying to use a cursor created by the worker thread in the main thread. This PR does not support their syntax however since they are awaiting `c.execute(...)` by itself, which would still return an sqlite3.Cursor here.