### PR TITLE
Fix pool connections remaining open after closure

### DIFF
--- a/asqlite/__init__.py
+++ b/asqlite/__init__.py
@@ -571,6 +571,9 @@ class ProxiedConnection(Connection):
         if self._in_use:
             await self._in_use
 
+    async def _unproxied_close(self) -> None:
+        await super().close()
+
 
 class _AcquireProxyContextManager:
     def __init__(self, pool: Pool) -> None:
@@ -749,7 +752,7 @@ class Pool:
             wait_for_release = [connection.wait_until_released() for connection in self._connections]
             await asyncio.gather(*wait_for_release)
 
-            close_all = [connection.close() for connection in self._connections]
+            close_all = [connection._unproxied_close() for connection in self._connections]
             await asyncio.gather(*close_all)
         except (Exception, asyncio.CancelledError):
             await self.terminate()
@@ -767,7 +770,7 @@ class Pool:
         if self._closed:
             return
 
-        close_all = [connection.close() for connection in self._connections]
+        close_all = [connection._unproxied_close() for connection in self._connections]
         await asyncio.gather(*close_all)
 
         for worker in self._workers:

--- a/asqlite/__init__.py
+++ b/asqlite/__init__.py
@@ -571,7 +571,7 @@ class ProxiedConnection(Connection):
         if self._in_use:
             await self._in_use
 
-    async def _unproxied_close(self) -> None:
+    async def _force_close(self) -> None:
         await super().close()
 
 
@@ -752,7 +752,7 @@ class Pool:
             wait_for_release = [connection.wait_until_released() for connection in self._connections]
             await asyncio.gather(*wait_for_release)
 
-            close_all = [connection._unproxied_close() for connection in self._connections]
+            close_all = [connection._force_close() for connection in self._connections]
             await asyncio.gather(*close_all)
         except (Exception, asyncio.CancelledError):
             await self.terminate()
@@ -770,7 +770,7 @@ class Pool:
         if self._closed:
             return
 
-        close_all = [connection._unproxied_close() for connection in self._connections]
+        close_all = [connection._force_close() for connection in self._connections]
         await asyncio.gather(*close_all)
 
         for worker in self._workers:


### PR DESCRIPTION
This PR fixes the underlying SQLite connections remaining alive after a pool's closure/termination by calling their non-proxied `Connection.close()` methods.

### Reproducible Example

The following example should successfully change the database's journal mode after the pool has been closed (which requires exclusively locking the database), rather than raising `sqlite3.OperationalError: database is locked`.

```py
import asyncio
import asqlite

DATABASE_FILE = "test.db"

async def main():
    async with asqlite.create_pool(DATABASE_FILE) as pool:
        pass

    async with asqlite.connect(DATABASE_FILE) as conn:
        await conn.execute("PRAGMA journal_mode = DELETE")

asyncio.run(main())
```